### PR TITLE
community: query_language has been removed in azure-search-documents==11.4.0

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -215,7 +215,6 @@ class AzureSearch(VectorStore):
         embedding_function: Callable,
         search_type: str = "hybrid",
         semantic_configuration_name: Optional[str] = None,
-        semantic_query_language: str = "en-us",
         fields: Optional[List[SearchField]] = None,
         vector_search: Optional[VectorSearch] = None,
         semantic_configurations: Optional[SemanticConfiguration] = None,
@@ -275,7 +274,6 @@ class AzureSearch(VectorStore):
         )
         self.search_type = search_type
         self.semantic_configuration_name = semantic_configuration_name
-        self.semantic_query_language = semantic_query_language
         self.fields = fields if fields else default_fields
 
     @property
@@ -552,7 +550,6 @@ class AzureSearch(VectorStore):
             ],
             filter=filters,
             query_type="semantic",
-            query_language=self.semantic_query_language,
             semantic_configuration_name=self.semantic_configuration_name,
             query_caption="extractive",
             query_answer="extractive",


### PR DESCRIPTION
- **Description:** This fixes a bug in [this ongoing PR](https://github.com/langchain-ai/langchain/pull/15659) where the `semantic_hybrid_search` method of `AzureSearch` yields an error because the field `query_language` has been removed in azure-search-documents>=11.4.0
- **Issue:** this is part of fixing the issues referenced in the [original PR](https://github.com/langchain-ai/langchain/pull/15659)
- **Dependencies:** azure-search-documents>=11.4.0